### PR TITLE
ensure runit is installed before trying to use it

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+include_recipe 'runit'
 include_recipe "rbenv"
 include_recipe "rbenv::ruby_build"
 


### PR DESCRIPTION
Include the `runit` recipe since it's a dependency of the `gem_server::server` recipe. Right now including the `gem_server::server` recipe fails unless you've already included the `runit` recipe in your run list or wrapper cookbook.
